### PR TITLE
Specify in package.json bridge-pca uses ES module syntax

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,20 +9,20 @@
       "version": "0.1.6",
       "license": "W3 License",
       "dependencies": {
-        "colorparsley": "^0.1.6"
+        "colorparsley": "^0.1.8"
       }
     },
     "node_modules/colorparsley": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/colorparsley/-/colorparsley-0.1.6.tgz",
-      "integrity": "sha512-fiK4goizsGw+Ak/nV5JshYcb2lrJC+sTdg+MXQRja4SeCA+caWLWLodAbJJJVcnuyypNlpmjPH9ktuojlvbimQ=="
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/colorparsley/-/colorparsley-0.1.8.tgz",
+      "integrity": "sha512-rObESTTTE6G5qO5WFwFxWPggpw4KfpxnLC6Ssl8bITBnNVRhDsyCeTRAUxWQNVTx2pRknKlO2nddYTxjkdNFaw=="
     }
   },
   "dependencies": {
     "colorparsley": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/colorparsley/-/colorparsley-0.1.6.tgz",
-      "integrity": "sha512-fiK4goizsGw+Ak/nV5JshYcb2lrJC+sTdg+MXQRja4SeCA+caWLWLodAbJJJVcnuyypNlpmjPH9ktuojlvbimQ=="
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/colorparsley/-/colorparsley-0.1.8.tgz",
+      "integrity": "sha512-rObESTTTE6G5qO5WFwFxWPggpw4KfpxnLC6Ssl8bITBnNVRhDsyCeTRAUxWQNVTx2pRknKlO2nddYTxjkdNFaw=="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bridge-pca",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bridge-pca",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "W3 License",
       "dependencies": {
         "colorparsley": "^0.1.8"

--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "colorparsley": "^0.1.6"
+    "colorparsley": "^0.1.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bridge-pca",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "type": "module",
   "description": "A Bridge for WCAG_2 contrast using APCA (Advanced Perceptual Contrast Algorithm), technology.",
   "main": "./src/bridge-pca.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "bridge-pca",
   "version": "0.1.6",
+  "type": "module",
   "description": "A Bridge for WCAG_2 contrast using APCA (Advanced Perceptual Contrast Algorithm), technology.",
   "main": "./src/bridge-pca.js",
   "keywords": [


### PR DESCRIPTION
Like your other projects that already have it (`colorparsley` and `apca-w3`), this project should have `"type": "module"` specified to allow it to be used in Node.js projects with ES modules.

I figured it might be convenient to update the version number already, but please let me know if I better leave it out.

By the way: thanks for all your great work on accessible colors, it has been ever so helpful!